### PR TITLE
Get ticket information from TradingView alert

### DIFF
--- a/TradingViewInteractiveBrokers/app.py
+++ b/TradingViewInteractiveBrokers/app.py
@@ -36,8 +36,8 @@ async def check_if_reconnect():
                 "%b %d %H:%M:%S")) + " Reconnect Success")
         except Exception as e:
             exc_type, exc_obj, exc_tb = sys.exc_info()
-            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-            print(exc_type, fname, exc_tb.tb_lineno)
+            file_name = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+            print(exc_type, file_name, exc_tb.tb_lineno)
             print("Make sure TWS or Gateway is open with the correct port")
             print((datetime.now().strftime(
                 "%b %d %H:%M:%S")) + " : " + str(e))
@@ -55,8 +55,8 @@ async def webhook(request):
         ticker = str(data['symbol'])
         # Buying stock
         order = MarketOrder("BUY", 1, account=app_ib.wrapper.accounts[0])
-        contract = Stock('SPY', 'SMART', 'USD')
-        # contract = Stock(ticker, 'SMART', 'USD')
+        contract = Stock(ticker, 'SMART', 'USD')
+        # contract = contract_type_check(ticker=ticker)
         print((datetime.now().strftime(
             "%b %d %H:%M:%S")) + " Buying: " + ticker)
         # Placing order

--- a/TradingViewInteractiveBrokers/contract.py
+++ b/TradingViewInteractiveBrokers/contract.py
@@ -1,0 +1,22 @@
+from ib_insync import Contract
+
+
+def contract_type_check(ticker: str) -> Contract:
+    contract = Contract()
+    contract.symbol = ticker
+    if ticker == "SPY":
+        contract.secType = "STK"
+        contract.currency = "USD"
+        contract.exchange = "ARCA"
+    elif ticker[0:3] == "ETH":
+        contract.secType = "CRYPTO"
+        contract.currency = "USD"
+        contract.exchange = "PAXOS"
+    elif ticker[0:3] == "EUR":
+        contract.secType = "CASH"
+        contract.currency = "USD"
+        contract.exchange = "IDEALPRO"
+    else:
+        print(f"It seems there is no ticker {ticker} in TWS.\n"
+              f"Please, check it one more time and modify the alert message")
+    return contract


### PR DESCRIPTION
In the following branch, I've:

- added the contract.py module to check the type of ticker from the TradingView alert. The following module is still developing, and the functionality will be expanded.
- refactored variables names in the ./app.py
- added ticker var that gets symbol from TradingView alert `{{ticker}}`